### PR TITLE
Add h2 5.0.0 compat patch

### DIFF
--- a/duniverse/README.md
+++ b/duniverse/README.md
@@ -1,0 +1,24 @@
+# duniverse
+
+This folder contains vendored source code of the dependencies of the project,
+created by the [opam-monorepo](https://github.com/ocamllabs/opam-monorepo)
+tool. You can find the packages and versions that are included in this folder
+in the `.opam.locked` files.
+
+To update the packages do not modify the files and directories by hand, instead
+use `opam-monorepo` to keep the lockfiles and directory contents accurate and
+in sync:
+
+```sh
+opam monorepo lock 
+opam monorepo pull
+```
+
+If you happen to include the `duniverse/` folder in your Git repository make
+sure to commit all files:
+
+```sh
+git add -A duniverse/
+```
+
+For more information check out the homepage and manual of `opam-monorepo`.

--- a/duniverse/dream/.gitmodules
+++ b/duniverse/dream/.gitmodules
@@ -9,7 +9,8 @@
 	url = https://github.com/aantron/websocketaf.git
 [submodule "src/vendor/h2"]
 	path = src/vendor/h2
-	url = https://github.com/aantron/ocaml-h2.git
+	url = https://github.com/patricoferris/ocaml-h2.git
+	branch = 5.0.0
 [submodule "src/vendor/paf"]
 	path = src/vendor/paf
 	url = https://github.com/dinosaure/paf-le-chien.git

--- a/duniverse/dream/src/vendor/h2/lib/scheduler.ml
+++ b/duniverse/dream/src/vendor/h2/lib/scheduler.ml
@@ -37,6 +37,10 @@ module StreamsTbl = struct
     let equal = Stream_identifier.( === )
 
     let hash i k = Hashtbl.seeded_hash i k
+
+    (* Required for OCaml >= 5.0.0, but causes errors for older compilers
+       because it is an unused value declaration. *)
+    let [@warning "-32"] seeded_hash = hash
   end)
 
   let[@inline] find_opt h key = try Some (find h key) with Not_found -> None

--- a/multicore-monorepo.opam
+++ b/multicore-monorepo.opam
@@ -5,7 +5,7 @@ authors: ["patrick@sirref.org"]
 homepage: "https://github.com/patricoferris/ocaml-multicore-monorepo"
 bug-reports: "https://github.com/patricoferris/ocaml-multicore-monorepo/issues"
 depends: [
-  "ocaml-variants" {= "5.00.0+trunk" }
+  "ocaml-variants" {= "5.0.0+trunk" }
   "dune" {>= "2.9.2"}
   "eio_main" {>= "0.2"}
   "lwt_eio"

--- a/multicore-monorepo.opam.locked
+++ b/multicore-monorepo.opam.locked
@@ -2,107 +2,107 @@ opam-version: "2.0"
 synopsis: "opam-monorepo generated lockfile"
 maintainer: "opam-monorepo"
 depends: [
-  "angstrom" {= "0.15.0" & vendor}
-  "astring" {= "0.8.5+dune" & vendor}
-  "base" {= "v0.14.0" & vendor}
+  "angstrom" {= "0.15.0" & ?vendor}
+  "astring" {= "0.8.5+dune" & ?vendor}
+  "base" {= "v0.14.0" & ?vendor}
   "base-bigarray" {= "base"}
   "base-bytes" {= "base"}
   "base-domains" {= "base"}
   "base-nnp" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
-  "base64" {= "3.5.0" & vendor}
-  "bigarray-compat" {= "1.1.0" & vendor}
-  "bigarray-overlap" {= "0.2.0" & vendor}
-  "bigstringaf" {= "0.8.0" & vendor}
-  "biniou" {= "1.2.1" & vendor}
-  "bisect_ppx" {= "2.7.1" & vendor}
-  "camlp-streams" {= "5.0" & vendor}
-  "caqti" {= "1.6.0" & vendor}
-  "caqti-lwt" {= "1.6.0" & vendor}
-  "cmdliner" {= "1.1.0+dune" & vendor}
+  "base64" {= "3.5.0" & ?vendor}
+  "bigarray-compat" {= "1.1.0" & ?vendor}
+  "bigarray-overlap" {= "0.2.0" & ?vendor}
+  "bigstringaf" {= "0.8.0" & ?vendor}
+  "biniou" {= "1.2.1" & ?vendor}
+  "bisect_ppx" {= "2.7.1" & ?vendor}
+  "camlp-streams" {= "5.0" & ?vendor}
+  "caqti" {= "1.6.0" & ?vendor}
+  "caqti-lwt" {= "1.6.0" & ?vendor}
+  "cmdliner" {= "1.1.0+dune" & ?vendor}
   "conf-libev" {= "4-12"}
   "conf-pkg-config" {= "2"}
-  "cppo" {= "1.6.8" & vendor}
-  "csexp" {= "1.5.1" & vendor}
-  "cstruct" {= "6.0.1" & vendor}
-  "ctypes" {= "0.17.1+dune" & vendor}
-  "digestif" {= "1.1.0" & vendor}
-  "domainslib" {= "0.4.2" & vendor}
-  "dream" {= "1.0.0~alpha2" & vendor}
-  "dream-httpaf" {= "~dev" & vendor}
-  "dream-pure" {= "~dev" & vendor}
+  "cppo" {= "1.6.8" & ?vendor}
+  "csexp" {= "1.5.1" & ?vendor}
+  "cstruct" {= "6.0.1" & ?vendor}
+  "ctypes" {= "0.17.1+dune" & ?vendor}
+  "digestif" {= "1.1.0" & ?vendor}
+  "domainslib" {= "0.4.2" & ?vendor}
+  "dream" {= "1.0.0~alpha2" & ?vendor}
+  "dream-httpaf" {= "~dev" & ?vendor}
+  "dream-pure" {= "~dev" & ?vendor}
   "dune" {= "3.0.3"}
-  "dune-configurator" {= "2.9.3" & vendor}
-  "duration" {= "0.2.0" & vendor}
-  "easy-format" {= "1.3.2" & vendor}
-  "eio" {= "0.2" & vendor}
-  "eio_linux" {= "0.2" & vendor}
-  "eio_luv" {= "0.2" & vendor}
-  "eio_main" {= "0.2" & vendor}
-  "eqaf" {= "0.8" & vendor}
-  "faraday" {= "0.8.1" & vendor}
-  "faraday-lwt" {= "0.8.1" & vendor}
-  "faraday-lwt-unix" {= "0.8.1" & vendor}
-  "findlib" {= "1.8.1+dune" & vendor}
-  "fmt" {= "0.8.10+dune" & vendor}
-  "graphql" {= "0.13.0" & vendor}
-  "graphql-lwt" {= "0.13.0" & vendor}
-  "graphql_parser" {= "0.13.0" & vendor}
-  "hmap" {= "0.8.0+dune" & vendor}
-  "integers" {= "0.5.1" & vendor}
-  "js_of_ocaml" {= "4.0.0" & vendor}
-  "js_of_ocaml-compiler" {= "4.0.0" & vendor}
-  "js_of_ocaml-lwt" {= "4.0.0" & vendor}
-  "js_of_ocaml-ppx" {= "4.0.0" & vendor}
-  "ke" {= "0.4" & vendor}
-  "logs" {= "0.7.0+dune" & vendor}
-  "luv" {= "0.5.11" & vendor}
-  "luv_unix" {= "0.5.0" & vendor}
-  "lwt" {= "5.5.0" & vendor}
-  "lwt-dllist" {= "1.0.1" & vendor}
-  "lwt_eio" {= "0.1" & vendor}
-  "lwt_ppx" {= "2.0.3" & vendor}
-  "magic-mime" {= "1.2.0" & vendor}
-  "mdx" {= "2.1.0" & vendor}
-  "menhir" {= "20211012" & vendor}
-  "menhirLib" {= "20211012" & vendor}
-  "menhirSdk" {= "20211012" & vendor}
-  "mirage-clock" {= "4.1.0" & vendor}
-  "mirage-crypto" {= "0.10.5" & vendor}
-  "mirage-crypto-rng" {= "0.10.5" & vendor}
-  "mmap" {= "1.1.0" & vendor}
-  "mtime" {= "1.2.0+dune" & vendor}
-  "multipart_form" {= "0.3.0" & vendor}
+  "dune-configurator" {= "2.9.3" & ?vendor}
+  "duration" {= "0.2.0" & ?vendor}
+  "easy-format" {= "1.3.2" & ?vendor}
+  "eio" {= "0.2" & ?vendor}
+  "eio_linux" {= "0.2" & ?vendor}
+  "eio_luv" {= "0.2" & ?vendor}
+  "eio_main" {= "0.2" & ?vendor}
+  "eqaf" {= "0.8" & ?vendor}
+  "faraday" {= "0.8.1" & ?vendor}
+  "faraday-lwt" {= "0.8.1" & ?vendor}
+  "faraday-lwt-unix" {= "0.8.1" & ?vendor}
+  "findlib" {= "1.8.1+dune" & ?vendor}
+  "fmt" {= "0.8.10+dune" & ?vendor}
+  "graphql" {= "0.13.0" & ?vendor}
+  "graphql-lwt" {= "0.13.0" & ?vendor}
+  "graphql_parser" {= "0.13.0" & ?vendor}
+  "hmap" {= "0.8.0+dune" & ?vendor}
+  "integers" {= "0.5.1" & ?vendor}
+  "js_of_ocaml" {= "4.0.0" & ?vendor}
+  "js_of_ocaml-compiler" {= "4.0.0" & ?vendor}
+  "js_of_ocaml-lwt" {= "4.0.0" & ?vendor}
+  "js_of_ocaml-ppx" {= "4.0.0" & ?vendor}
+  "ke" {= "0.4" & ?vendor}
+  "logs" {= "0.7.0+dune" & ?vendor}
+  "luv" {= "0.5.11" & ?vendor}
+  "luv_unix" {= "0.5.0" & ?vendor}
+  "lwt" {= "5.5.0" & ?vendor}
+  "lwt-dllist" {= "1.0.1" & ?vendor}
+  "lwt_eio" {= "0.1" & ?vendor}
+  "lwt_ppx" {= "2.0.3" & ?vendor}
+  "magic-mime" {= "1.2.0" & ?vendor}
+  "mdx" {= "2.1.0" & ?vendor}
+  "menhir" {= "20211012" & ?vendor}
+  "menhirLib" {= "20211012" & ?vendor}
+  "menhirSdk" {= "20211012" & ?vendor}
+  "mirage-clock" {= "4.1.0" & ?vendor}
+  "mirage-crypto" {= "0.10.5" & ?vendor}
+  "mirage-crypto-rng" {= "0.10.5" & ?vendor}
+  "mmap" {= "1.1.0" & ?vendor}
+  "mtime" {= "1.2.0+dune" & ?vendor}
+  "multipart_form" {= "0.3.0" & ?vendor}
   "ocaml" {= "5.0.0"}
-  "ocaml-compiler-libs" {= "v0.12.4" & vendor}
+  "ocaml-compiler-libs" {= "v0.12.4" & ?vendor}
   "ocaml-config" {= "2"}
-  "ocaml-syntax-shims" {= "1.0.0" & vendor}
+  "ocaml-syntax-shims" {= "1.0.0" & ?vendor}
   "ocaml-variants" {= "5.0.0+trunk"}
-  "ocaml-version" {= "3.4.0" & vendor}
-  "ocamlfind" {= "1.8.0.git" & vendor}
-  "ocplib-endian" {= "1.2" & vendor}
-  "odoc-parser" {= "1.0.0" & vendor}
-  "optint" {= "0.1.0" & vendor}
-  "pecu" {= "0.6" & vendor}
-  "ppx_derivers" {= "1.2.1" & vendor}
-  "ppxlib" {= "0.25.0~5.00preview" & vendor}
-  "prettym" {= "0.0.2" & vendor}
-  "psq" {= "0.2.0" & vendor}
-  "ptime" {= "0.8.6" & vendor}
-  "re" {= "1.10.3" & vendor}
-  "result" {= "1.5" & vendor}
-  "rresult" {= "0.6.0+dune" & vendor}
-  "seq" {= "base+dune" & vendor}
-  "sexplib0" {= "v0.14.0" & vendor}
-  "stdlib-shims" {= "0.3.0" & vendor}
-  "stringext" {= "1.6.0" & vendor}
-  "uchar" {= "0.0.2+dune" & vendor}
-  "unstrctrd" {= "0.3" & vendor}
-  "uri" {= "4.2.0" & vendor}
-  "uring" {= "0.3" & vendor}
-  "uutf" {= "1.0.3" & vendor}
-  "yojson" {= "1.7.0" & vendor}
+  "ocaml-version" {= "3.4.0" & ?vendor}
+  "ocamlfind" {= "1.8.0.git" & ?vendor}
+  "ocplib-endian" {= "1.2" & ?vendor}
+  "odoc-parser" {= "1.0.0" & ?vendor}
+  "optint" {= "0.1.0" & ?vendor}
+  "pecu" {= "0.6" & ?vendor}
+  "ppx_derivers" {= "1.2.1" & ?vendor}
+  "ppxlib" {= "0.25.0~5.00preview" & ?vendor}
+  "prettym" {= "0.0.2" & ?vendor}
+  "psq" {= "0.2.0" & ?vendor}
+  "ptime" {= "0.8.6" & ?vendor}
+  "re" {= "1.10.3" & ?vendor}
+  "result" {= "1.5" & ?vendor}
+  "rresult" {= "0.6.0+dune" & ?vendor}
+  "seq" {= "base+dune" & ?vendor}
+  "sexplib0" {= "v0.14.0" & ?vendor}
+  "stdlib-shims" {= "0.3.0" & ?vendor}
+  "stringext" {= "1.6.0" & ?vendor}
+  "uchar" {= "0.0.2+dune" & ?vendor}
+  "unstrctrd" {= "0.3" & ?vendor}
+  "uri" {= "4.2.0" & ?vendor}
+  "uring" {= "0.3" & ?vendor}
+  "uutf" {= "1.0.3" & ?vendor}
+  "yojson" {= "1.7.0" & ?vendor}
 ]
 depexts: [
   ["devel/pkgconf"] {os = "openbsd"}
@@ -214,15 +214,15 @@ pin-depends: [
   ]
   [
     "dream.1.0.0~alpha2"
-    "git+https://github.com/patricoferris/dream#2d3066cb87611a0df9c3a7e875b714ecbf25a84b"
+    "git+https://github.com/patricoferris/dream#61333452f9ee41f7652b4c23027a478b82737b22"
   ]
   [
     "dream-httpaf.~dev"
-    "git+https://github.com/patricoferris/dream#2d3066cb87611a0df9c3a7e875b714ecbf25a84b"
+    "git+https://github.com/patricoferris/dream#61333452f9ee41f7652b4c23027a478b82737b22"
   ]
   [
     "dream-pure.~dev"
-    "git+https://github.com/patricoferris/dream#2d3066cb87611a0df9c3a7e875b714ecbf25a84b"
+    "git+https://github.com/patricoferris/dream#61333452f9ee41f7652b4c23027a478b82737b22"
   ]
   [
     "dune-configurator.2.9.3"
@@ -631,23 +631,14 @@ x-opam-monorepo-duniverse-dirs: [
   [
     "https://github.com/ocaml-multicore/domainslib/archive/0.4.2.tar.gz"
     "domainslib"
-    ["md5=a079b8b5b676e8d38d713f02b25b14db"]
   ]
   [
     "https://github.com/ocaml-multicore/eio/releases/download/v0.2/eio_main-0.2.tbz"
     "eio"
-    [
-      "sha256=d09b63460ab8eb529b7e48c5a566ece58ae0d8f3c72ef6b55245cd8a8b3b304d"
-      "sha512=d644a0495923fc6c009d6ca95693ad93ed204604dcf84f43c68f3e83f4ab1bb6c4581c14b165ffaec2c194803a6dac38611e991133acdfc3388a7fa95a677d32"
-    ]
   ]
   [
     "https://github.com/ocaml-multicore/ocaml-uring/releases/download/v0.3/uring-0.3.tbz"
     "ocaml-uring"
-    [
-      "sha256=47c225fce95ad34dd38c35f30724f7d8111afd4370d301985abc720747c6d746"
-      "sha512=af093ea00aa57d02a32f27708a3a6ebc9e3b6d509ecbe0c88b0ba85ec57a23131c51c5009b40a3ef4a63568ad9d2793bff73e7cf7ba149b9ea5ce12b41d2aafa"
-    ]
   ]
   [
     "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz"
@@ -690,7 +681,7 @@ x-opam-monorepo-duniverse-dirs: [
     "cmdliner"
   ]
   [
-    "git+https://github.com/patricoferris/dream#2d3066cb87611a0df9c3a7e875b714ecbf25a84b"
+    "git+https://github.com/patricoferris/dream#61333452f9ee41f7652b4c23027a478b82737b22"
     "dream"
   ]
   [
@@ -763,4 +754,4 @@ x-opam-monorepo-duniverse-dirs: [
   ]
 ]
 x-opam-monorepo-root-packages: ["multicore-monorepo"]
-x-opam-monorepo-version: "0.2"
+x-opam-monorepo-version: "0.3"


### PR DESCRIPTION
This PR adds the h2 patch to the Dream Eio port. Originally discovered on the forum: https://discuss.ocaml.org/t/awesome-multicore-ocaml-and-multicore-monorepo/9515

Thanks @dangdennis for the report. 